### PR TITLE
Automatic image comparison for measuring similarity between reference and rendered images

### DIFF
--- a/test_scenes/victorious_lucian_splash/camera.gd
+++ b/test_scenes/victorious_lucian_splash/camera.gd
@@ -1,0 +1,14 @@
+@tool
+extends Camera3D
+
+@export var look_target : Marker3D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	look_at(look_target.global_position)

--- a/test_scenes/victorious_lucian_splash/camera.gd.uid
+++ b/test_scenes/victorious_lucian_splash/camera.gd.uid
@@ -1,0 +1,1 @@
+uid://cx7ekq328fxx4

--- a/test_scenes/victorious_lucian_splash/default_scene.tscn
+++ b/test_scenes/victorious_lucian_splash/default_scene.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://ckft8neuknrwk"]
 
 [ext_resource type="PackedScene" uid="uid://bncvx1kw5or07" path="res://test_scenes/victorious_lucian_splash/sketch.gltf" id="1_iaf6v"]
+[ext_resource type="Script" uid="uid://cx7ekq328fxx4" path="res://test_scenes/victorious_lucian_splash/camera.gd" id="2_k8c47"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_2n4on"]
 sky_top_color = Color(0.49803922, 0.49803922, 0.59607846, 1)
@@ -27,18 +28,32 @@ adjustment_enabled = true
 adjustment_contrast = 1.2
 adjustment_saturation = 1.5
 
+[sub_resource type="CameraAttributesPractical" id="CameraAttributesPractical_iaf6v"]
+
 [node name="defaultScene" unique_id=1347612653 instance=ExtResource("1_iaf6v")]
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="." index="0" unique_id=1101120030]
 environment = SubResource("Environment_iaf6v")
+camera_attributes = SubResource("CameraAttributesPractical_iaf6v")
 
 [node name="Sun" type="DirectionalLight3D" parent="." index="1" unique_id=1393562335]
-transform = Transform3D(-0.47840708, 0.35484144, 0.8032523, 0.8736674, 0.100146815, 0.47610494, 0.08849861, 0.9295474, -0.3579244, 3.531418, 3.8447485, -1.825481)
+transform = Transform3D(0.22665131, -0.76540583, 0.6023149, 0, 0.61840844, 0.7858569, -0.97397596, -0.17811552, 0.14016306, 3.531418, 3.8447485, -1.825481)
 light_color = Color(0.9684753, 0.8118291, 0.62693506, 1)
-light_energy = 4.0
 light_angular_distance = 0.1
 shadow_enabled = true
+directional_shadow_blend_splits = true
+directional_shadow_max_distance = 25.0
 
-[node name="Camera" parent="." index="3" unique_id=1074576640]
-transform = Transform3D(0.40749007, 0.09854367, -0.9078771, 0.008146358, 0.9937289, 0.111518666, 0.9131732, -0.052838646, 0.40413192, -1.6648853, 1.011374, 0.3523099)
-fov = 54.3
+[node name="node_Smoke_70d79cca-b159-4f35-990c-f02193947fe8_0_i0_mesh_Smoke_70d79cca-b159-4f35-990c-f02193947fe8_0_i0" parent="Node/Node2/Node3/node_Smoke_70d79cca-b159-4f35-990c-f02193947fe8_0_i0" parent_id_path=PackedInt32Array(270962440) index="0" unique_id=208571962]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.7791672, 0)
+
+[node name="Camera" parent="." index="3" unique_id=1074576640 node_paths=PackedStringArray("look_target")]
+transform = Transform3D(0.45010847, 0.20175809, -0.869877, 0, 0.9741343, 0.22593985, 0.8929717, -0.101697534, 0.43846738, -1.3645909, 1.0945637, 0.4130437)
+fov = 60.6
+far = 1000.0
+script = ExtResource("2_k8c47")
+look_target = NodePath("../CameraTarget")
+
+[node name="CameraTarget" type="Marker3D" parent="." index="4" unique_id=153732778]
+transform = Transform3D(0.3391136, 0.15744725, -0.92747635, 0.01696822, 0.98471105, 0.17336744, 0.9405924, -0.07452888, 0.3312573, -0.36126196, 0.83396137, -0.092691086)
+top_level = true

--- a/test_scenes/victorious_lucian_splash/visual_comparison.gd
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.gd
@@ -1,0 +1,166 @@
+extends Control
+
+@export var viewport: SubViewport
+@export var reference : Control
+@export var render : Control
+
+@export var label : RichTextLabel
+
+@export var resolution_spin_box: SpinBox
+@export var blur_spin_box: SpinBox
+
+var metrics_previous : Dictionary
+
+#
+#func _ready() -> void:
+	#set_process($CheckBox.button_pressed)
+	#
+func _ready() -> void:
+	compare(resolution_spin_box.value, blur_spin_box.value)
+	%PreviewPanel.hide()
+	if %AutoCheckBox.button_pressed:
+		%Timer.start()
+
+
+func push_good():
+	label.push_color(Color.BLACK)
+	label.push_bgcolor(Color.GREEN)
+
+func push_bad():
+	label.push_color(Color.WHITE)
+	label.push_bgcolor(Color.DARK_RED)
+	
+	
+func push_neutral():
+	label.push_color(Color.GHOST_WHITE)
+	label.push_bgcolor(Color.DEEP_SKY_BLUE)
+
+
+func compare(resolution: int, blur: float):
+	reference.show()
+	render.hide()
+	render.modulate = Color(1, 1, 1, 1)
+	#self.hide()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var img1 = viewport.get_texture().get_image()
+	render.show()
+	reference.hide()
+	await get_tree().process_frame
+	var img2 = viewport.get_texture().get_image()
+	# in theory trilinear resize should generate missing mipmaps anyway, but the results from this are smoother
+	img1.generate_mipmaps()
+	img2.generate_mipmaps()
+	img1.resize(resolution, resolution, Image.INTERPOLATE_TRILINEAR)
+	img2.resize(resolution, resolution, Image.INTERPOLATE_TRILINEAR)
+	
+	%Img1.texture = ImageTexture.create_from_image(img1)
+	%Img2.texture = ImageTexture.create_from_image(img2)
+	
+	%PreviewPanel.show()
+	
+	label.clear()
+	var metrics = img1.compute_image_metrics(img2, false)
+	
+	#if metrics_previous.hash() == metrics.hash():
+		#print("No change!")
+		#return
+	
+	# first run only
+	if metrics_previous.is_empty():
+		metrics_previous = metrics
+	
+	label.push_table(4)
+	for i in metrics.keys():
+		label.push_cell()
+		label.push_mono()
+		label.append_text("%s" % i)
+		label.pop()
+		label.pop()
+		if metrics_previous.keys().has(i):
+			label.push_cell()
+			label.push_mono()
+			label.push_color(Color(1,1,1,0.5))
+			label.append_text("%2.1f" % metrics_previous[i])
+			label.pop()
+			label.pop()
+			label.push_cell()
+			label.append_text("   ")
+			label.push_bold()
+			label.push_mono()
+			var invert = false
+			if i == "peak_snr":
+				invert = true
+			if metrics_previous[i] > metrics[i] + 0.1:
+				if not invert:
+					push_good()
+				else:
+					push_bad()
+				label.append_text(" ↓ ")
+			elif metrics_previous[i] < metrics[i] - 0.1:
+				if not invert:
+					push_bad()
+				else:
+					push_good()
+				label.append_text(" ↑ ")
+			else:
+				push_neutral()
+				label.append_text(" ~ ")
+			label.pop() # mono
+			label.pop() # bgcolor
+			label.pop() # color
+			label.pop() # bold
+			label.pop() # cell
+			label.push_cell()
+		label.pop()
+		label.push_cell()
+		label.push_mono()
+		label.append_text("%2.1f" % metrics[i])
+		label.pop()
+		label.pop()
+	label.pop() # table
+	
+	reference.show()
+	render.show()
+	render.modulate = Color(1, 1, 1, 0.5)
+	
+	metrics_previous = metrics
+
+
+
+func _on_button_pressed() -> void:
+	compare(resolution_spin_box.value, blur_spin_box.value)
+	
+
+#func _process(_delta) -> void:
+	#compare()
+
+
+func _on_check_box_toggled(toggled_on: bool) -> void:
+	if toggled_on:
+		%Timer.start()
+	else:
+		%Timer.stop()
+
+
+func _on_timer_timeout() -> void:
+	compare(resolution_spin_box.value, blur_spin_box.value)
+
+
+func _on_check_button_toggled(toggled_on: bool) -> void:
+	if toggled_on:
+		reference.show()
+		render.hide()
+		%CheckButton.text = "B"
+	else:
+		%CheckButton.text = "A"
+		render.show()
+		reference.hide()
+		render.modulate = Color(1,1,1,1)
+
+	%PreviewPanel.hide()
+	hide()
+
+
+func _on_check_button_mouse_exited() -> void:
+	show()

--- a/test_scenes/victorious_lucian_splash/visual_comparison.gd
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.gd
@@ -16,6 +16,7 @@ var metrics_previous : Dictionary
 	#set_process($CheckBox.button_pressed)
 	#
 func _ready() -> void:
+	render.set_instance_shader_parameter(&"display_mode", %ModeSelector.selected) # initialize
 	compare(resolution_spin_box.value, blur_spin_box.value)
 	%PreviewPanel.hide()
 	if %AutoCheckBox.button_pressed:
@@ -37,17 +38,22 @@ func push_neutral():
 
 
 func compare(resolution: int, blur: float):
-	reference.show()
-	render.hide()
-	render.modulate = Color(1, 1, 1, 1)
+	#reference.show()
+	#render.hide()
+	var previous_display_mode = render.get_instance_shader_parameter(&"display_mode")
+	render.set_instance_shader_parameter(&"display_mode", 0) # show reference
+	#render.modulate = Color(1, 1, 1, 1)
 	#self.hide()
 	await get_tree().process_frame
 	await get_tree().process_frame
-	var img1 = viewport.get_texture().get_image()
-	render.show()
-	reference.hide()
+	var img1 = viewport.get_texture().get_image() # capture reference
+	render.set_instance_shader_parameter(&"display_mode", 1) # show render
+	#render.show()
+	#reference.hide()
 	await get_tree().process_frame
-	var img2 = viewport.get_texture().get_image()
+	await get_tree().process_frame
+	var img2 = viewport.get_texture().get_image() # capture render
+	render.set_instance_shader_parameter(&"display_mode", previous_display_mode) # restore user set value
 	# in theory trilinear resize should generate missing mipmaps anyway, but the results from this are smoother
 	img1.generate_mipmaps()
 	img2.generate_mipmaps()
@@ -120,9 +126,9 @@ func compare(resolution: int, blur: float):
 		label.pop()
 	label.pop() # table
 	
-	reference.show()
-	render.show()
-	render.modulate = Color(1, 1, 1, 0.5)
+	#reference.show()
+	#render.show()
+	#render.modulate = Color(1, 1, 1, 0.5)
 	
 	metrics_previous = metrics
 
@@ -146,21 +152,9 @@ func _on_check_box_toggled(toggled_on: bool) -> void:
 func _on_timer_timeout() -> void:
 	compare(resolution_spin_box.value, blur_spin_box.value)
 
-
-func _on_check_button_toggled(toggled_on: bool) -> void:
-	if toggled_on:
-		reference.show()
-		render.hide()
-		%CheckButton.text = "B"
-	else:
-		%CheckButton.text = "A"
-		render.show()
-		reference.hide()
-		render.modulate = Color(1,1,1,1)
-
-	%PreviewPanel.hide()
-	hide()
-
-
-func _on_check_button_mouse_exited() -> void:
+func _on_mode_selector_mouse_exited() -> void:
 	show()
+
+
+func _on_mode_selector_item_selected(index: int) -> void:
+	render.set_instance_shader_parameter(&"display_mode", index)

--- a/test_scenes/victorious_lucian_splash/visual_comparison.gd
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.gd
@@ -1,15 +1,17 @@
 extends Control
 
 @export var viewport: SubViewport
-@export var reference : Control
-@export var render : Control
+@export var reference: Control
+@export var render: Control
 
-@export var label : RichTextLabel
+@export var label: RichTextLabel
 
 @export var resolution_spin_box: SpinBox
 @export var blur_spin_box: SpinBox
 
-var metrics_previous : Dictionary
+var metrics_previous: Dictionary
+
+var img2_previous: Image
 
 #
 #func _ready() -> void:
@@ -20,7 +22,7 @@ func _ready() -> void:
 	compare(resolution_spin_box.value, blur_spin_box.value)
 	%PreviewPanel.hide()
 	if %AutoCheckBox.button_pressed:
-		%Timer.start()
+		%Timer.start(1.0 / %AutoFreq.value)
 
 
 func push_good():
@@ -38,27 +40,44 @@ func push_neutral():
 
 
 func compare(resolution: int, blur: float):
-	#reference.show()
-	#render.hide()
+	var antiflicker_img = viewport.get_texture().get_image() # capture current render
+	%AntiFlicker.texture = ImageTexture.create_from_image(antiflicker_img)
+	%AntiFlicker.show()
+	# store for later
 	var previous_display_mode = render.get_instance_shader_parameter(&"display_mode")
-	render.set_instance_shader_parameter(&"display_mode", 0) # show reference
-	#render.modulate = Color(1, 1, 1, 1)
-	#self.hide()
-	await get_tree().process_frame
-	await get_tree().process_frame
-	var img1 = viewport.get_texture().get_image() # capture reference
+	
+	# grab render image
 	render.set_instance_shader_parameter(&"display_mode", 1) # show render
-	#render.show()
-	#reference.hide()
 	await get_tree().process_frame
 	await get_tree().process_frame
 	var img2 = viewport.get_texture().get_image() # capture render
+	img2.generate_mipmaps()
+	img2.resize(resolution, resolution, Image.INTERPOLATE_TRILINEAR)
+	
+	# compare to previous render to see if there's a point to doing more work
+	var metrics_to_prev = img2.compute_image_metrics(img2_previous, false)
+	
+	#print()
+	if metrics_to_prev["mean_squared"] < 0.05:
+		# the render has not changed since last frame,
+		# there's no point in updating the comparison data, we'll only loose sight of trends (improvements, declines)
+		render.set_instance_shader_parameter(&"display_mode", previous_display_mode)
+		#print("No change")
+		return
+	
+	# save for later so we can compare next time
+	img2_previous = img2
+	
+	# grab reference image
+	render.set_instance_shader_parameter(&"display_mode", 0) # show reference
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var img1 = viewport.get_texture().get_image() # capture reference
+	
 	render.set_instance_shader_parameter(&"display_mode", previous_display_mode) # restore user set value
 	# in theory trilinear resize should generate missing mipmaps anyway, but the results from this are smoother
 	img1.generate_mipmaps()
-	img2.generate_mipmaps()
 	img1.resize(resolution, resolution, Image.INTERPOLATE_TRILINEAR)
-	img2.resize(resolution, resolution, Image.INTERPOLATE_TRILINEAR)
 	
 	%Img1.texture = ImageTexture.create_from_image(img1)
 	%Img2.texture = ImageTexture.create_from_image(img2)
@@ -90,7 +109,7 @@ func compare(resolution: int, blur: float):
 			label.append_text("%2.1f" % metrics_previous[i])
 			label.pop()
 			label.pop()
-			label.push_cell()
+			#label.push_cell()
 			label.append_text("   ")
 			label.push_bold()
 			label.push_mono()
@@ -131,6 +150,7 @@ func compare(resolution: int, blur: float):
 	#render.modulate = Color(1, 1, 1, 0.5)
 	
 	metrics_previous = metrics
+	%AntiFlicker.hide()
 
 
 
@@ -144,7 +164,7 @@ func _on_button_pressed() -> void:
 
 func _on_check_box_toggled(toggled_on: bool) -> void:
 	if toggled_on:
-		%Timer.start()
+		%Timer.start(1.0 / %AutoFreq.value)
 	else:
 		%Timer.stop()
 
@@ -158,3 +178,17 @@ func _on_mode_selector_mouse_exited() -> void:
 
 func _on_mode_selector_item_selected(index: int) -> void:
 	render.set_instance_shader_parameter(&"display_mode", index)
+	%AntiFlicker.hide()
+	%PreviewPanel.hide()
+	show()
+
+
+func _on_auto_freq_value_changed(value: float) -> void:
+	%Timer.wait_time = 1.0 / value
+
+
+func _on_mode_selector_item_focused(index: int) -> void:
+	render.set_instance_shader_parameter(&"display_mode", index)
+	%AntiFlicker.hide()
+	hide()
+	%PreviewPanel.hide()

--- a/test_scenes/victorious_lucian_splash/visual_comparison.gd
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.gd
@@ -3,6 +3,7 @@ extends Control
 @export var viewport: SubViewport
 @export var reference: Control
 @export var render: Control
+@export var anti_flicker: TextureRect
 
 @export var label: RichTextLabel
 
@@ -19,6 +20,8 @@ var img2_previous: Image
 	#
 func _ready() -> void:
 	render.set_instance_shader_parameter(&"display_mode", %ModeSelector.selected) # initialize
+	anti_flicker.set_instance_shader_parameter(&"display_mode", %ModeSelector.selected) # initialize
+	%HeatMapFilter.visible = %ModeSelector.selected == 4;
 	compare(resolution_spin_box.value, blur_spin_box.value)
 	%PreviewPanel.hide()
 	if %AutoCheckBox.button_pressed:
@@ -41,13 +44,17 @@ func push_neutral():
 
 func compare(resolution: int, blur: float):
 	var antiflicker_img = viewport.get_texture().get_image() # capture current render
+	#antiflicker_img.generate_mipmaps()
 	%AntiFlicker.texture = ImageTexture.create_from_image(antiflicker_img)
 	%AntiFlicker.show()
+	await get_tree().process_frame
 	# store for later
 	var previous_display_mode = render.get_instance_shader_parameter(&"display_mode")
 	
 	# grab render image
 	render.set_instance_shader_parameter(&"display_mode", 1) # show render
+	#anti_flicker.set_instance_shader_parameter(&"display_mode", 1) # show render
+	#viewport_container.set_instance_shader_parameter(&"display_mode", 1) # show render
 	await get_tree().process_frame
 	await get_tree().process_frame
 	var img2 = viewport.get_texture().get_image() # capture render
@@ -62,6 +69,7 @@ func compare(resolution: int, blur: float):
 		# the render has not changed since last frame,
 		# there's no point in updating the comparison data, we'll only loose sight of trends (improvements, declines)
 		render.set_instance_shader_parameter(&"display_mode", previous_display_mode)
+		#anti_flicker.set_instance_shader_parameter(&"display_mode", previous_display_mode)
 		#print("No change")
 		return
 	
@@ -70,11 +78,13 @@ func compare(resolution: int, blur: float):
 	
 	# grab reference image
 	render.set_instance_shader_parameter(&"display_mode", 0) # show reference
+	#anti_flicker.set_instance_shader_parameter(&"display_mode", 0) # show reference
 	await get_tree().process_frame
 	await get_tree().process_frame
 	var img1 = viewport.get_texture().get_image() # capture reference
 	
 	render.set_instance_shader_parameter(&"display_mode", previous_display_mode) # restore user set value
+	#anti_flicker.set_instance_shader_parameter(&"display_mode", previous_display_mode) # restore user set value
 	# in theory trilinear resize should generate missing mipmaps anyway, but the results from this are smoother
 	img1.generate_mipmaps()
 	img1.resize(resolution, resolution, Image.INTERPOLATE_TRILINEAR)
@@ -178,6 +188,9 @@ func _on_mode_selector_mouse_exited() -> void:
 
 func _on_mode_selector_item_selected(index: int) -> void:
 	render.set_instance_shader_parameter(&"display_mode", index)
+	#anti_flicker.set_instance_shader_parameter(&"display_mode", index)
+	%HeatMapFilter.visible = index == 4;
+	
 	%AntiFlicker.hide()
 	%PreviewPanel.hide()
 	show()
@@ -189,6 +202,8 @@ func _on_auto_freq_value_changed(value: float) -> void:
 
 func _on_mode_selector_item_focused(index: int) -> void:
 	render.set_instance_shader_parameter(&"display_mode", index)
-	%AntiFlicker.hide()
-	hide()
-	%PreviewPanel.hide()
+	#anti_flicker.set_instance_shader_parameter(&"display_mode", index)
+	%HeatMapFilter.visible = index == 4;
+	#%AntiFlicker.hide()
+	#hide()
+	#%PreviewPanel.hide()

--- a/test_scenes/victorious_lucian_splash/visual_comparison.gd.uid
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.gd.uid
@@ -1,0 +1,1 @@
+uid://dpew2o2faip6k

--- a/test_scenes/victorious_lucian_splash/visual_comparison.gdshader
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.gdshader
@@ -1,0 +1,38 @@
+shader_type canvas_item;
+render_mode unshaded, blend_premul_alpha;
+
+instance uniform int display_mode = 2;
+// 0 - Reference
+// 1 - Result
+// 2 - Average
+// 3 - Difference
+
+void vertex() {
+	// Called for every vertex the material is visible on.
+}
+
+void fragment() {
+	switch (display_mode){
+		case 0:
+			COLOR = vec4(0.0);
+			COLOR.a = 0.0;
+			break;
+		case 1:
+			break;
+		case 2:
+			COLOR = COLOR / 2.0;
+			break;
+		case 3:
+			COLOR.rgb = 0.5 - COLOR.rgb / 2.0;
+			COLOR.a = 0.5;
+			break;
+		default:
+			break;
+	};
+}
+
+
+//void light() {
+//	// Called for every pixel for every light affecting the CanvasItem.
+//	// Uncomment to replace the default light processing function with this one.
+//}

--- a/test_scenes/victorious_lucian_splash/visual_comparison.gdshader.uid
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.gdshader.uid
@@ -1,0 +1,1 @@
+uid://civ3wbq3e037y

--- a/test_scenes/victorious_lucian_splash/visual_comparison.tscn
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.tscn
@@ -2,83 +2,210 @@
 
 [ext_resource type="PackedScene" uid="uid://ckft8neuknrwk" path="res://test_scenes/victorious_lucian_splash/default_scene.tscn" id="1_jk7we"]
 [ext_resource type="Texture2D" uid="uid://bbiiq6hyvyind" path="res://test_scenes/victorious_lucian_splash/screenshot_OpenBrush_victorious_lucial_splash.webp" id="2_jk7we"]
+[ext_resource type="Script" uid="uid://dpew2o2faip6k" path="res://test_scenes/victorious_lucian_splash/visual_comparison.gd" id="3_6mtyo"]
 
-[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_jk7we"]
-sky_top_color = Color(0.49803922, 0.49803922, 0.59607846, 1)
-sky_horizon_color = Color(0.38039216, 0.35686275, 0.45882353, 1)
-ground_bottom_color = Color(0.07058824, 0.05490196, 0.05490196, 1)
-ground_horizon_color = Color(0.45490196, 0.3764706, 0.5372549, 1)
-sun_angle_max = 0.0
-use_debanding = false
-energy_multiplier = 0.55
-
-[sub_resource type="Sky" id="Sky_6mtyo"]
-sky_material = SubResource("ProceduralSkyMaterial_jk7we")
-
-[sub_resource type="Environment" id="Environment_uday3"]
-background_mode = 2
-background_color = Color(0.16923234, 0.0564678, 0.26337764, 1)
-sky = SubResource("Sky_6mtyo")
-ambient_light_source = 3
-reflected_light_source = 2
-tonemap_exposure = 2.0
-adjustment_enabled = true
-adjustment_contrast = 1.2
-adjustment_saturation = 1.5
+[sub_resource type="SystemFont" id="SystemFont_6mtyo"]
+font_names = PackedStringArray("Monospace")
 
 [node name="VisualComparison" type="Node3D" unique_id=1155957687]
 
-[node name="HSplitContainer" type="HSplitContainer" parent="." unique_id=1181613159]
+[node name="SubViewportContainer" type="SubViewportContainer" parent="." unique_id=1143641616]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-split_offsets = PackedInt32Array(200)
-collapsed = true
-dragging_enabled = false
-dragger_visibility = 2
-split_offset = 200
 
-[node name="SubViewportContainer" type="SubViewportContainer" parent="HSplitContainer" unique_id=1933957529]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.5
-stretch = true
-
-[node name="SubViewport" type="SubViewport" parent="HSplitContainer/SubViewportContainer" unique_id=314659319]
+[node name="Viewport" type="SubViewport" parent="SubViewportContainer" unique_id=1043398115]
+unique_name_in_owner = true
 handle_input_locally = false
-msaa_3d = 2
-screen_space_aa = 2
-mesh_lod_threshold = 0.0
-size = Vector2i(576, 648)
+size = Vector2i(1152, 648)
 render_target_update_mode = 4
 
-[node name="defaultScene" parent="HSplitContainer/SubViewportContainer/SubViewport" unique_id=1347612653 instance=ExtResource("1_jk7we")]
-
-[node name="WorldEnvironment" parent="HSplitContainer/SubViewportContainer/SubViewport/defaultScene" index="0" unique_id=1101120030]
-environment = SubResource("Environment_uday3")
-
-[node name="Sun" parent="HSplitContainer/SubViewportContainer/SubViewport/defaultScene" index="1" unique_id=1393562335]
-transform = Transform3D(-0.7640486, -0.23060413, 0.60253763, 0.60484827, 0.06891377, 0.7933533, -0.22447367, 0.9706045, 0.08682702, 3.531, 3.19, 0.56)
-light_color = Color(0.97, 0.86136, 0.7372, 1)
-directional_shadow_split_1 = 0.05
-directional_shadow_split_2 = 0.075
-directional_shadow_blend_splits = true
-directional_shadow_max_distance = 30.0
-sky_mode = 1
-
-[node name="Camera" parent="HSplitContainer/SubViewportContainer/SubViewport/defaultScene" index="3" unique_id=1074576640]
-transform = Transform3D(0.4322665, 0.1992729, -0.87945193, 0.008502874, 0.97433287, 0.22495103, 0.9017056, -0.10471668, 0.4194771, -1.376, 1.081, 0.403)
-fov = 60.0
-far = 1000.0
-
-[node name="TextureRect" type="TextureRect" parent="HSplitContainer" unique_id=1235481503]
-layout_mode = 2
+[node name="Reference" type="TextureRect" parent="SubViewportContainer/Viewport" unique_id=1235481503]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -0.25335693
+offset_bottom = 0.25323486
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
 texture = ExtResource("2_jk7we")
 expand_mode = 5
 stretch_mode = 6
+metadata/_edit_lock_ = true
 
-[editable path="HSplitContainer/SubViewportContainer/SubViewport/defaultScene"]
+[node name="Render" type="SubViewportContainer" parent="SubViewportContainer/Viewport" unique_id=1933957529]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.5
+stretch = true
+metadata/_edit_lock_ = true
+metadata/_edit_group_ = true
+
+[node name="SubViewport" type="SubViewport" parent="SubViewportContainer/Viewport/Render" unique_id=314659319]
+handle_input_locally = false
+msaa_3d = 2
+screen_space_aa = 2
+mesh_lod_threshold = 0.0
+size = Vector2i(1152, 648)
+render_target_update_mode = 4
+
+[node name="defaultScene" parent="SubViewportContainer/Viewport/Render/SubViewport" unique_id=1347612653 instance=ExtResource("1_jk7we")]
+metadata/_edit_lock_ = true
+
+[node name="PreviewPanel" type="Panel" parent="." unique_id=86704273]
+unique_name_in_owner = true
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -129.0
+offset_top = -2.0
+offset_right = -129.0
+offset_bottom = -2.0
+grow_horizontal = 0
+grow_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+
+[node name="VBoxContainer" type="VBoxContainer" parent="PreviewPanel" unique_id=1008253329]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Img1" type="TextureRect" parent="PreviewPanel/VBoxContainer" unique_id=570300969]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 10
+stretch_mode = 2
+
+[node name="Img2" type="TextureRect" parent="PreviewPanel/VBoxContainer" unique_id=1745190160]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 2
+stretch_mode = 2
+
+[node name="CheckButton" type="CheckButton" parent="." unique_id=1683309164]
+unique_name_in_owner = true
+anchors_preset = -1
+anchor_right = 0.28500003
+anchor_bottom = 0.32900003
+offset_left = 12.0
+offset_top = 9.0
+offset_right = -257.32004
+offset_bottom = -173.19202
+tooltip_text = "toggle to switch between individual images"
+action_mode = 0
+button_mask = 7
+keep_pressed_outside = true
+text = "A"
+
+[node name="ControlPanel" type="Panel" parent="." unique_id=2096250504 node_paths=PackedStringArray("viewport", "reference", "render", "label", "resolution_spin_box", "blur_spin_box")]
+offset_left = -2.0
+offset_top = 440.0
+offset_right = 579.0
+offset_bottom = 650.0
+script = ExtResource("3_6mtyo")
+viewport = NodePath("../SubViewportContainer/Viewport")
+reference = NodePath("../SubViewportContainer/Viewport/Reference")
+render = NodePath("../SubViewportContainer/Viewport/Render")
+label = NodePath("Label")
+resolution_spin_box = NodePath("ResolutionSpinBox")
+blur_spin_box = NodePath("BlurSpinBox")
+
+[node name="Label" type="RichTextLabel" parent="ControlPanel" unique_id=328337251]
+layout_mode = 0
+offset_left = 15.0
+offset_top = 72.0
+offset_right = 573.0
+offset_bottom = 202.0
+theme_override_constants/line_separation = 0
+theme_override_constants/table_h_separation = 26
+theme_override_constants/table_v_separation = 2
+theme_override_fonts/mono_font = SubResource("SystemFont_6mtyo")
+fit_content = true
+autowrap_mode = 0
+autowrap_trim_flags = 0
+horizontal_alignment = 2
+vertical_alignment = 1
+
+[node name="Button" type="Button" parent="ControlPanel" unique_id=2101849920]
+layout_mode = 0
+offset_left = 14.0
+offset_top = 16.0
+offset_right = 128.0
+offset_bottom = 66.0
+text = "Compare
+"
+
+[node name="Timer" type="Timer" parent="ControlPanel" unique_id=1435681955]
+unique_name_in_owner = true
+
+[node name="AutoCheckBox" type="CheckBox" parent="ControlPanel" unique_id=1411619452]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 136.0
+offset_top = 26.0
+offset_right = 200.0
+offset_bottom = 57.0
+text = "auto"
+
+[node name="ResolutionSpinBox" type="SpinBox" parent="ControlPanel" unique_id=329204591]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 308.0
+offset_top = 18.0
+offset_right = 394.5
+offset_bottom = 63.0
+min_value = 8.0
+max_value = 1024.0
+value = 256.0
+allow_greater = true
+
+[node name="Label2" type="Label" parent="ControlPanel/ResolutionSpinBox" unique_id=843131856]
+layout_mode = 0
+offset_left = -96.0
+offset_top = 11.0
+offset_right = -16.0
+offset_bottom = 34.0
+text = "resolution"
+
+[node name="BlurSpinBox" type="SpinBox" parent="ControlPanel" unique_id=1299078760]
+unique_name_in_owner = true
+visible = false
+layout_mode = 0
+offset_left = 327.0
+offset_top = 91.0
+offset_right = 464.0
+offset_bottom = 136.0
+max_value = 1024.0
+step = 0.125
+value = 8.0
+allow_greater = true
+
+[node name="Label2" type="Label" parent="ControlPanel/BlurSpinBox" unique_id=1295996979]
+layout_mode = 0
+offset_left = -96.0
+offset_top = 11.0
+offset_right = -16.0
+offset_bottom = 34.0
+text = "blur"
+
+[connection signal="mouse_exited" from="CheckButton" to="ControlPanel" method="_on_check_button_mouse_exited"]
+[connection signal="toggled" from="CheckButton" to="ControlPanel" method="_on_check_button_toggled"]
+[connection signal="pressed" from="ControlPanel/Button" to="ControlPanel" method="_on_button_pressed"]
+[connection signal="timeout" from="ControlPanel/Timer" to="ControlPanel" method="_on_timer_timeout"]
+[connection signal="toggled" from="ControlPanel/AutoCheckBox" to="ControlPanel" method="_on_check_box_toggled"]

--- a/test_scenes/victorious_lucian_splash/visual_comparison.tscn
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.tscn
@@ -2,7 +2,11 @@
 
 [ext_resource type="PackedScene" uid="uid://ckft8neuknrwk" path="res://test_scenes/victorious_lucian_splash/default_scene.tscn" id="1_jk7we"]
 [ext_resource type="Texture2D" uid="uid://bbiiq6hyvyind" path="res://test_scenes/victorious_lucian_splash/screenshot_OpenBrush_victorious_lucial_splash.webp" id="2_jk7we"]
+[ext_resource type="Shader" uid="uid://civ3wbq3e037y" path="res://test_scenes/victorious_lucian_splash/visual_comparison.gdshader" id="2_uday3"]
 [ext_resource type="Script" uid="uid://dpew2o2faip6k" path="res://test_scenes/victorious_lucian_splash/visual_comparison.gd" id="3_6mtyo"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_2cpu2"]
+shader = ExtResource("2_uday3")
 
 [sub_resource type="SystemFont" id="SystemFont_6mtyo"]
 font_names = PackedStringArray("Monospace")
@@ -38,6 +42,8 @@ stretch_mode = 6
 metadata/_edit_lock_ = true
 
 [node name="Render" type="SubViewportContainer" parent="SubViewportContainer/Viewport" unique_id=1933957529]
+material = SubResource("ShaderMaterial_2cpu2")
+instance_shader_parameters/display_mode = 0
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -51,8 +57,6 @@ metadata/_edit_group_ = true
 
 [node name="SubViewport" type="SubViewport" parent="SubViewportContainer/Viewport/Render" unique_id=314659319]
 handle_input_locally = false
-msaa_3d = 2
-screen_space_aa = 2
 mesh_lod_threshold = 0.0
 size = Vector2i(1152, 648)
 render_target_update_mode = 4
@@ -98,7 +102,7 @@ size_flags_horizontal = 4
 size_flags_vertical = 2
 stretch_mode = 2
 
-[node name="CheckButton" type="CheckButton" parent="." unique_id=1683309164]
+[node name="ModeSelector" type="OptionButton" parent="." unique_id=1288065097]
 unique_name_in_owner = true
 anchors_preset = -1
 anchor_right = 0.28500003
@@ -108,10 +112,18 @@ offset_top = 9.0
 offset_right = -257.32004
 offset_bottom = -173.19202
 tooltip_text = "toggle to switch between individual images"
-action_mode = 0
 button_mask = 7
 keep_pressed_outside = true
-text = "A"
+selected = 3
+item_count = 4
+popup/item_0/text = "Reference"
+popup/item_0/id = 0
+popup/item_1/text = "Result"
+popup/item_1/id = 1
+popup/item_2/text = "Average"
+popup/item_2/id = 3
+popup/item_3/text = "Difference"
+popup/item_3/id = 2
 
 [node name="ControlPanel" type="Panel" parent="." unique_id=2096250504 node_paths=PackedStringArray("viewport", "reference", "render", "label", "resolution_spin_box", "blur_spin_box")]
 offset_left = -2.0
@@ -204,8 +216,8 @@ offset_right = -16.0
 offset_bottom = 34.0
 text = "blur"
 
-[connection signal="mouse_exited" from="CheckButton" to="ControlPanel" method="_on_check_button_mouse_exited"]
-[connection signal="toggled" from="CheckButton" to="ControlPanel" method="_on_check_button_toggled"]
+[connection signal="item_selected" from="ModeSelector" to="ControlPanel" method="_on_mode_selector_item_selected"]
+[connection signal="mouse_exited" from="ModeSelector" to="ControlPanel" method="_on_mode_selector_mouse_exited"]
 [connection signal="pressed" from="ControlPanel/Button" to="ControlPanel" method="_on_button_pressed"]
 [connection signal="timeout" from="ControlPanel/Timer" to="ControlPanel" method="_on_timer_timeout"]
 [connection signal="toggled" from="ControlPanel/AutoCheckBox" to="ControlPanel" method="_on_check_box_toggled"]

--- a/test_scenes/victorious_lucian_splash/visual_comparison.tscn
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.tscn
@@ -1,5 +1,6 @@
 [gd_scene format=3 uid="uid://bd4r7gwb72wxi"]
 
+[ext_resource type="Shader" uid="uid://qoi4t1khaehx" path="res://test_scenes/victorious_lucian_splash/visual_comparison_heatmap.gdshader" id="1_2cpu2"]
 [ext_resource type="PackedScene" uid="uid://ckft8neuknrwk" path="res://test_scenes/victorious_lucian_splash/default_scene.tscn" id="1_jk7we"]
 [ext_resource type="Texture2D" uid="uid://bbiiq6hyvyind" path="res://test_scenes/victorious_lucian_splash/screenshot_OpenBrush_victorious_lucial_splash.webp" id="2_jk7we"]
 [ext_resource type="Shader" uid="uid://civ3wbq3e037y" path="res://test_scenes/victorious_lucian_splash/visual_comparison.gdshader" id="2_uday3"]
@@ -8,12 +9,31 @@
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_2cpu2"]
 shader = ExtResource("2_uday3")
 
+[sub_resource type="Gradient" id="Gradient_2cpu2"]
+interpolation_color_space = 2
+offsets = PackedFloat32Array(0, 0.20169851, 0.38641188, 0.6220807, 0.81104034, 1)
+colors = PackedColorArray(0, 0, 0, 1, 0, 0, 1, 1, 0.4333334, 1, 0, 1, 0.9607843, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1)
+
+[sub_resource type="GradientTexture1D" id="GradientTexture1D_a5dvo"]
+gradient = SubResource("Gradient_2cpu2")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_a5dvo"]
+shader = ExtResource("1_2cpu2")
+shader_parameter/gradient = SubResource("GradientTexture1D_a5dvo")
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_2cpu2"]
+viewport_path = NodePath("SubViewportContainer/Viewport")
+
 [sub_resource type="SystemFont" id="SystemFont_6mtyo"]
 font_names = PackedStringArray("Monospace")
+subpixel_positioning = 0
 
 [node name="VisualComparison" type="Node3D" unique_id=1155957687]
 
 [node name="SubViewportContainer" type="SubViewportContainer" parent="." unique_id=1143641616]
+unique_name_in_owner = true
+texture_filter = 4
+texture_repeat = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -23,6 +43,8 @@ grow_vertical = 2
 [node name="Viewport" type="SubViewport" parent="SubViewportContainer" unique_id=1043398115]
 unique_name_in_owner = true
 handle_input_locally = false
+msaa_2d = 2
+canvas_item_default_texture_filter = 2
 size = Vector2i(1152, 648)
 render_target_update_mode = 4
 
@@ -66,13 +88,30 @@ metadata/_edit_lock_ = true
 
 [node name="AntiFlicker" type="TextureRect" parent="." unique_id=2084285890]
 unique_name_in_owner = true
+visible = false
+texture_filter = 4
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -0.25335693
+offset_bottom = 0.2532959
+grow_horizontal = 2
+grow_vertical = 2
+expand_mode = 5
+stretch_mode = 6
+
+[node name="HeatMapFilter" type="TextureRect" parent="." unique_id=1092785372]
+unique_name_in_owner = true
+visible = false
+texture_filter = 4
+material = SubResource("ShaderMaterial_a5dvo")
+instance_shader_parameters/display_mode = 4
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-expand_mode = 5
-stretch_mode = 6
+texture = SubResource("ViewportTexture_2cpu2")
 
 [node name="PreviewPanel" type="Panel" parent="." unique_id=86704273]
 unique_name_in_owner = true
@@ -124,8 +163,8 @@ offset_bottom = -173.19202
 tooltip_text = "toggle to switch between individual images"
 button_mask = 7
 keep_pressed_outside = true
-selected = 3
-item_count = 4
+selected = 4
+item_count = 5
 popup/item_0/text = "Reference"
 popup/item_0/id = 0
 popup/item_1/text = "Result"
@@ -134,8 +173,10 @@ popup/item_2/text = "Average"
 popup/item_2/id = 3
 popup/item_3/text = "Difference"
 popup/item_3/id = 2
+popup/item_4/text = "Difference Heatmap"
+popup/item_4/id = 4
 
-[node name="ControlPanel" type="Panel" parent="." unique_id=2096250504 node_paths=PackedStringArray("viewport", "reference", "render", "label", "resolution_spin_box", "blur_spin_box")]
+[node name="ControlPanel" type="Panel" parent="." unique_id=2096250504 node_paths=PackedStringArray("viewport", "reference", "render", "anti_flicker", "label", "resolution_spin_box", "blur_spin_box")]
 offset_left = -2.0
 offset_top = 440.0
 offset_right = 579.0
@@ -144,6 +185,7 @@ script = ExtResource("3_6mtyo")
 viewport = NodePath("../SubViewportContainer/Viewport")
 reference = NodePath("../SubViewportContainer/Viewport/Reference")
 render = NodePath("../SubViewportContainer/Viewport/Render")
+anti_flicker = NodePath("../AntiFlicker")
 label = NodePath("Label")
 resolution_spin_box = NodePath("ResolutionSpinBox")
 blur_spin_box = NodePath("BlurSpinBox")

--- a/test_scenes/victorious_lucian_splash/visual_comparison.tscn
+++ b/test_scenes/victorious_lucian_splash/visual_comparison.tscn
@@ -64,6 +64,16 @@ render_target_update_mode = 4
 [node name="defaultScene" parent="SubViewportContainer/Viewport/Render/SubViewport" unique_id=1347612653 instance=ExtResource("1_jk7we")]
 metadata/_edit_lock_ = true
 
+[node name="AntiFlicker" type="TextureRect" parent="." unique_id=2084285890]
+unique_name_in_owner = true
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+expand_mode = 5
+stretch_mode = 6
+
 [node name="PreviewPanel" type="Panel" parent="." unique_id=86704273]
 unique_name_in_owner = true
 anchors_preset = 6
@@ -173,15 +183,31 @@ offset_left = 136.0
 offset_top = 26.0
 offset_right = 200.0
 offset_bottom = 57.0
+button_pressed = true
 text = "auto"
+
+[node name="AutoFreq" type="HSlider" parent="ControlPanel/AutoCheckBox" unique_id=1156324131]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 80.0
+offset_top = -5.0
+offset_right = 228.0
+offset_bottom = 32.0
+tooltip_text = "auto update frequency"
+min_value = 1.0
+max_value = 20.0
+value = 2.0
+exp_edit = true
+tick_count = 20
+ticks_on_borders = true
 
 [node name="ResolutionSpinBox" type="SpinBox" parent="ControlPanel" unique_id=329204591]
 unique_name_in_owner = true
 layout_mode = 0
-offset_left = 308.0
-offset_top = 18.0
-offset_right = 394.5
-offset_bottom = 63.0
+offset_left = 476.0
+offset_top = 15.0
+offset_right = 562.5
+offset_bottom = 60.0
 min_value = 8.0
 max_value = 1024.0
 value = 256.0
@@ -216,8 +242,10 @@ offset_right = -16.0
 offset_bottom = 34.0
 text = "blur"
 
+[connection signal="item_focused" from="ModeSelector" to="ControlPanel" method="_on_mode_selector_item_focused"]
 [connection signal="item_selected" from="ModeSelector" to="ControlPanel" method="_on_mode_selector_item_selected"]
 [connection signal="mouse_exited" from="ModeSelector" to="ControlPanel" method="_on_mode_selector_mouse_exited"]
 [connection signal="pressed" from="ControlPanel/Button" to="ControlPanel" method="_on_button_pressed"]
 [connection signal="timeout" from="ControlPanel/Timer" to="ControlPanel" method="_on_timer_timeout"]
 [connection signal="toggled" from="ControlPanel/AutoCheckBox" to="ControlPanel" method="_on_check_box_toggled"]
+[connection signal="value_changed" from="ControlPanel/AutoCheckBox/AutoFreq" to="ControlPanel" method="_on_auto_freq_value_changed"]

--- a/test_scenes/victorious_lucian_splash/visual_comparison_heatmap.gdshader
+++ b/test_scenes/victorious_lucian_splash/visual_comparison_heatmap.gdshader
@@ -1,12 +1,9 @@
 shader_type canvas_item;
-render_mode unshaded, blend_premul_alpha;
 
 instance uniform int display_mode = 2;
-// 0 - Reference
-// 1 - Result
-// 2 - Average
-// 3 - Difference
-// 4 - Difference Heatmap
+instance uniform float mip = 0.0;
+uniform sampler2D gradient;
+uniform sampler2D screen_texture: hint_screen_texture, filter_linear_mipmap;
 
 void vertex() {
 	// Called for every vertex the material is visible on.
@@ -15,27 +12,19 @@ void vertex() {
 void fragment() {
 	switch (display_mode){
 		case 0: // Reference
-			COLOR = vec4(0.0);
-			COLOR.a = 0.0;
 			break;
 		case 1: // Result
 			break;
 		case 2: // Average
-			COLOR = COLOR / 2.0;
 			break;
 		case 3: // Difference
-			COLOR.rgb = 0.5 - COLOR.rgb / 2.0;
-			COLOR.a = 0.5;
 			break;
 		case 4: // Difference Heatmap
-			COLOR.rgb = 0.5 - COLOR.rgb / 2.0;
-			COLOR.a = 0.5;
-			break;
+	COLOR = texture(gradient, vec2(distance(textureLod(screen_texture, SCREEN_UV, mip).rgb, vec3(0.5)), 0.5));
 		default:
 			break;
 	};
 }
-
 
 //void light() {
 //	// Called for every pixel for every light affecting the CanvasItem.

--- a/test_scenes/victorious_lucian_splash/visual_comparison_heatmap.gdshader.uid
+++ b/test_scenes/victorious_lucian_splash/visual_comparison_heatmap.gdshader.uid
@@ -1,0 +1,1 @@
+uid://qoi4t1khaehx

--- a/test_scenes/victorious_lucian_splash/visual_comparison_test.tscn
+++ b/test_scenes/victorious_lucian_splash/visual_comparison_test.tscn
@@ -12,6 +12,7 @@ fill = 2
 fill_from = Vector2(0.5, 0.5)
 
 [sub_resource type="Gradient" id="Gradient_be5m5"]
+colors = PackedColorArray(0, 0, 0, 1, 0.98265713, 0.98400563, 0.98265713, 1)
 
 [sub_resource type="GradientTexture2D" id="GradientTexture2D_b3ep6"]
 gradient = SubResource("Gradient_be5m5")
@@ -19,6 +20,9 @@ width = 512
 height = 512
 fill = 2
 fill_from = Vector2(0.5, 0.5)
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_ktp83"]
+viewport_path = NodePath("SubViewportContainer/Viewport")
 
 [node name="VisualComparison" unique_id=1155957687 instance=ExtResource("1_ktp83")]
 
@@ -41,3 +45,6 @@ grow_vertical = 2
 texture = SubResource("GradientTexture2D_b3ep6")
 expand_mode = 1
 flip_h = true
+
+[node name="HeatMapFilter" parent="." index="2" unique_id=1092785372]
+texture = SubResource("ViewportTexture_ktp83")

--- a/test_scenes/victorious_lucian_splash/visual_comparison_test.tscn
+++ b/test_scenes/victorious_lucian_splash/visual_comparison_test.tscn
@@ -1,0 +1,43 @@
+[gd_scene format=3 uid="uid://c3fde64myx0rq"]
+
+[ext_resource type="PackedScene" uid="uid://bd4r7gwb72wxi" path="res://test_scenes/victorious_lucian_splash/visual_comparison.tscn" id="1_ktp83"]
+
+[sub_resource type="Gradient" id="Gradient_ktp83"]
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_xdqq5"]
+gradient = SubResource("Gradient_ktp83")
+width = 512
+height = 512
+fill = 2
+fill_from = Vector2(0.5, 0.5)
+
+[sub_resource type="Gradient" id="Gradient_be5m5"]
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_b3ep6"]
+gradient = SubResource("Gradient_be5m5")
+width = 512
+height = 512
+fill = 2
+fill_from = Vector2(0.5, 0.5)
+
+[node name="VisualComparison" unique_id=1155957687 instance=ExtResource("1_ktp83")]
+
+[node name="Reference" parent="SubViewportContainer/Viewport" parent_id_path=PackedInt32Array(1043398115) index="0" unique_id=1235481503]
+offset_top = 0.0
+offset_bottom = 0.0
+texture = SubResource("GradientTexture2D_xdqq5")
+expand_mode = 1
+stretch_mode = 0
+
+[node name="defaultScene" parent="SubViewportContainer/Viewport/Render/SubViewport" parent_id_path=PackedInt32Array(314659319) index="0" unique_id=1347612653]
+visible = false
+
+[node name="TextureRect" type="TextureRect" parent="SubViewportContainer/Viewport/Render/SubViewport" parent_id_path=PackedInt32Array(314659319) index="1" unique_id=836102863]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = SubResource("GradientTexture2D_b3ep6")
+expand_mode = 1
+flip_h = true


### PR DESCRIPTION
This branch is meant to implements tools to measure how well we reproduce results from OpenBrush.

A test scene uses a screenshot from OpenBrush and a scene viewport with aligned camera (by hand) in order to spot differences and be able to objectively note improvement or regressions of our visual reproduction of Tilt and OpenBrush scenes in Godot.